### PR TITLE
Layout fixes

### DIFF
--- a/pages/index_new.md
+++ b/pages/index_new.md
@@ -1,6 +1,5 @@
-<h2 class="midl">International Conference on</h2>
 <h1 class="midl">Medical&nbsp;Imaging with Deep&nbsp;Learning</h1>
-<h2 class="centered">Lübeck, 7 ‑ 9th July 2021</h2>
+<h2 class="midl">Lübeck, 7 ‑ 9th July 2021</h2>
 
 <p class="primary-photo centered">
     <img alt="City of Lübeck" src="/images/midl_2021_luebeck.png">

--- a/pages/organization.md
+++ b/pages/organization.md
@@ -19,11 +19,6 @@ title: "Organization"
 * [Jannis Hagenah](https://www.rob.uni-luebeck.de/index.php?id=422&L=1), Institute for Robotics and Cognitive Sciences, University of Lübeck, Germany
 * [Alessa Hering](https://www.mevis.fraunhofer.de/en/employees/alessa-hering.html), Fraunhofer MEVIS, Lübeck, Germany
 
-## Web & Social Media
-
-* Hoël Kervadec (ÉTS Montréal)
-* Nikolas Lessmann (Radboud University Medical Center, The Netherlands)
-
 ## Area Chairs
 
 * To be determined

--- a/pages/venue.md
+++ b/pages/venue.md
@@ -7,7 +7,7 @@ title: "Venue"
 ## The Hanseatic City of Lübeck
 
 ![Panoramic view of the river Trave](/images/panorama.jpg)
-*(c) LTM - Manfred Krellenberg*
+<span class="credits">&copy; LTM - Manfred Krellenberg</span>
 
 MIDL will be held in Lübeck, the Queen of the Hanseatic League. The city was founded in 1143 “as the first occidental city at the Baltic coast” and, with its exemplary character, stands for all Hanseatic cities of the Baltic countries. Medieval ambience and historic sites determine until today the cityscape and are monuments of the important history as a Free and Hanseatic City. The Old Town Peninsula, surrounded by water, with its historic town centre is one of the most famous relics of the brick-lined gothic culture. For more than seven hundred years, Lübeck’s seven church spires have been the signature of the city’s silhouette. The University of Lübeck is located in the south of the city, at the heart of the BioMedTec Campus, a thriving community of small and medium companies centred around the University of Lübeck, the University Hospital Schleswig-Holstein, and the adjacent Technical University of Lübeck.
  
@@ -20,24 +20,24 @@ MIDL 2021 will take place in Lübeck's Music and Congress Hall (Musik- und Kongr
 The Musik- und Kongresshalle Lübeck hosts around 300 events every year. A total of 15 conference rooms, the VIP lounge, the gallery, the rotunda, the orchestra hall and the concert hall offer space for up to 3,500 people. The heart of the event house is the concert hall with its famous acoustics. A striking architectural feature is the white solitaire, created by the internationally renowned architect Meinhard von Gerkan, directly on the river Trave at the entrance to the historic Old Town Peninsula. The city centre and the railway station are within walking distance. Further information: [www.muk.de](www.muk.de) 
 
 ![Music and Concert Hall](/images/venue/muk.jpg)
-*(c) Olaf Malzahn*
+<span class="credits">&copy; Olaf Malzahn</span>
 
 The keynotes and oral sessions will be presented in the main concert hall.
 
 ![The Main Auditorium](/images/venue/muk_konzertsaal.jpg)
-*(c) Olaf Malzahn*
+<span class="credits">&copy; Olaf Malzahn</span>
 
 The poster sessions and the industry exhibition will be in the foyer, the galleries and the small concert hall.
 
 ![Small Concert Hall](/images/venue/muk_kleiner_saal.jpg)
-*(c) Olaf Malzahn*
+<span class="credits">&copy; Olaf Malzahn</span>
 
 ## Gala Dinner
 
 The social event will take place in a very special location: we have secured the use of the largest and most impressive church in Lübeck, [https://st-marien-luebeck.de/](St. Mary’s Church). It was built between 1250 and 1350. Being the tallest brick vault in the world, the central nave is more than 38m high. During World War II, the church was heavily damaged and has been rebuilt in the following decades. Historically, this is the church of Lübeck’s bourgeoisie, and has been used for various secular events. During the late middle ages and the renaissance, the church was used for trade fairs and other public gatherings, as it was the only building large enough to cater for large groups of people. 
 
 ![St. Marien zu Lübeck](/images/venue/marienkirche.jpg)
-*(c) Roland Meinecke, licensed under [GFPL 1.2](http://www.gnu.org/licenses/old-licenses/fdl-1.2.html)*
+<span class="credits">&copy; Roland Meinecke, licensed under [GFPL 1.2](http://www.gnu.org/licenses/old-licenses/fdl-1.2.html)</span>
 
 ![John Madejski Garden](/images/venue/marienkirche-innen.jpg)
-*(c) [Photography by André Leisner](https://photography-leisner.de/)*
+<span class="credits">&copy; [Photography by André Leisner](https://photography-leisner.de/)</span>


### PR DESCRIPTION
A few small fixes - we don't use the "International conference on" bit anymore, and there is a dedicated CSS class for credits below images (see also e.g. the homepage of the 2018 site).