### PR TITLE
Resolve a few small issues in program.html

### DIFF
--- a/pages/program.html
+++ b/pages/program.html
@@ -1,4 +1,20 @@
 <style>
+#program, #program th, #program td {
+    border: 1px solid gray;
+    font-size: 85%;
+    border-collapse: separate;
+    border-spacing: 1px;
+}
+@media (min-width: 1200px) {
+    #program {
+        margin-left: -50px;
+        margin-right: -50px;
+    }
+}
+#program th, #program td {
+  padding: 5px;
+  text-align: left;
+}
 #hide-show-timezones {
     font-size: 90%;
     margin-top: 1em;
@@ -17,16 +33,6 @@
     padding: 0 4px 0 8px;
 }
 
-#program, #program th, #program td {
-    border: 1px solid gray;
-    font-size: 87%;
-    border-collapse: separate;
-    border-spacing: 1px;
-}
-#program th, #program td {
-  padding: 5px;
-  text-align: left;
-}
 #r00{
       background-color: #96B6BD;
  /*   appearance: none;*/


### PR DESCRIPTION
Hi Mattias, a few changes to the program.html file - it contains `<head>` and  `<body>` tags, which are not necessary because the content of this file is embedded into the HTML of the entire page. It also loads the jQuery library which is already standardly loaded. For spacing paragraphs apart, the default stylesheets expect paragraphs to be wrapped in `<p>` tags instead of using `<br>` tags, so I've replaced them in a few places. Generally, horizontal lines can be used to make dense content more "airy" (see also the websites from previous years for examples).

The stylesheets embedded in the program.html file overwrite the default font, which should be avoided - the whole purpose of making it so complicated to define custom stylesheets is to make sure that all MIDL websites look similar, so ideally the program table should stick with the default font.

It would be good to turn this into a .md file (stylesheet, javascript and table can then still be HTML, everything inside a HTML tag is interpreted as HTML). Turning it into a Markdown file would make it possible to use the "paper" macro for the list of papers at the bottom. This macro was used on all previous sites to render the individual papers and presents links to OpenReview etc in a standardized way. For an example of what the Markdown syntax looks like, see https://github.com/MIDL-Conference/midl-website-2019/blob/master/pages/program/full-papers.md

Let me know if I can help with anything.